### PR TITLE
Typo Fix and Conversion to C++11

### DIFF
--- a/evosoro/_voxcad/Makefile
+++ b/evosoro/_voxcad/Makefile
@@ -12,7 +12,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DQT_XML_LIB -DQT_OPENGL_LIB -DUSE_ZLIB_COMPRESSION -DUSE_OPEN_GL -DQT_DLL -DPREC_MED -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED
 CFLAGS        = -m64 -pipe -g -Wall -W -D_REENTRANT $(DEFINES)
-CXXFLAGS      = -m64 -pipe -g -Wall -W -D_REENTRANT $(DEFINES)
+CXXFLAGS      = -std=c++11 -m64 -pipe -g -Wall -W -D_REENTRANT $(DEFINES)
 INCPATH       = -I/usr/share/qt4/mkspecs/linux-g++-64 -I. -I/usr/include/qt4/QtCore -I/usr/include/qt4/QtGui -I/usr/include/qt4/QtOpenGL -I/usr/include/qt4/QtXml -I/usr/include/qt4 -I../../../../Libs/qwt/src -I. -I./../Voxelyze -I../Voxelyze -I./GeneratedFiles/$(Configuration) -IGeneratedFiles -I./../Utils -I/usr/include/qwt -I/usr/X11R6/include -IGeneratedFiles/release -IGeneratedFiles
 LINK          = g++
 LFLAGS        = -m64

--- a/evosoro/_voxcad/VoxCad.pro
+++ b/evosoro/_voxcad/VoxCad.pro
@@ -7,6 +7,7 @@ TARGET = VoxCad
 DESTDIR = release
 QT += core gui xml opengl
 CONFIG += debug
+CONFIG += c++11
 DEFINES += QT_XML_LIB QT_OPENGL_LIB USE_ZLIB_COMPRESSION USE_OPEN_GL QT_DLL PREC_MED
 INCLUDEPATH += ../../../../Libs/qwt/src \
     . \

--- a/evosoro/_voxcad/VoxCad/QVX_Interface.cpp
+++ b/evosoro/_voxcad/VoxCad/QVX_Interface.cpp
@@ -30,7 +30,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #ifdef WIN32
 #define LOCALSLEEP Sleep
 #else
-#define LOCALSLEEP sleep
+#include <unistd.h>
+#define LOCALSLEEP(__X) usleep((__X)*1000)
 #endif
 
 #define DEFAULT_DISPLAY_UPDATE_MS 33 //normally updates the view at 30fps (33ms)

--- a/evosoro/_voxcad/Voxelyze/Makefile
+++ b/evosoro/_voxcad/Voxelyze/Makefile
@@ -30,7 +30,7 @@ INCLUDE= -I./Voxelyze -I./Voxelyze/Utils
 CFLAGS= -O3 -Wall -std=c++11 $(INCLUDE)
 #CFLAGS= -g -Wall $(INCLUDE)
 
-CPPFLAGS= $(CFLAGS)
+CXXFLAGS= $(CFLAGS)
 
 Vox_src = \
 	VX_Benchmark.cpp \


### PR DESCRIPTION
Fixed typo at evosoro/_voxcad/Voxelyze/Makefile
Converted to C++11
Changed sleep too usleep